### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,15 @@ package_dirs={'pyradarmet'}
 #datafiles = [os.path.join('data',os.path.basename(f)) for f in datafiles]
 #package_data = {'pyradarmet':datafiles}
 
+# Check for Pyart package - Avoid conflict with PyPI
+
+try:
+    import pyart.io
+except ImportError as e:
+    print("Could not find Pyart Install")
+    sys.exit()
+
+
 #- Run setup
 setup(
       name='pyradarmet',
@@ -66,5 +75,5 @@ A toolkit that contains a variety of utilities that can be used
 * Calculate geometrical characterisistics of radar
 * Calculate variables from radar output
 * Calculate ZDR bias of radar system""",
-      install_requires = ['Numpy >=1.7.2','pyart >= 1.0.0'],
+      install_requires = ['Numpy >=1.7.2'],
       )

--- a/setup.py
+++ b/setup.py
@@ -66,5 +66,5 @@ A toolkit that contains a variety of utilities that can be used
 * Calculate geometrical characterisistics of radar
 * Calculate variables from radar output
 * Calculate ZDR bias of radar system""",
-      install_requires = ['Numpy >=1.7.2','pyart'],
+      install_requires = ['Numpy >=1.7.2','pyart >= 1.0.0'],
       )


### PR DESCRIPTION
This I think will stop the wrong pyart package from being installed(unless it ever crosses version 1.0). 

This PR changes there require to request a version of pyart that is greater than the python adaptive radix tree currently on PyPI. This should make an install without the atmos pyart library fail, and stop pip from thinking it can fulfill the requirement with the wrong package. 
If the atmos pyart package is installed, I believe this should not change anything.
Wait to merge, need to test this on my system real quick
